### PR TITLE
Fix invalid json response

### DIFF
--- a/clamrest.go
+++ b/clamrest.go
@@ -113,7 +113,7 @@ func scanHandler(w http.ResponseWriter, r *http.Request) {
 			response, err := c.ScanStream(part, abort)
 			for s := range response {
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				respJson := fmt.Sprintf("{ Status: \"%s\", Description: \"%s\" }", s.Status, s.Description)
+				respJson := fmt.Sprintf("{ \"Status\": \"%s\", \"Description\": \"%s\" }", s.Status, s.Description)
 				switch s.Status {
 				case clamd.RES_OK:
 					w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The response was missing quotes around the JSON field names, so it was invalid JSON. This fixes that :)