### PR TITLE
Fix go build >= 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN freshclam --quiet --no-dns
 
 # Build go package
 ADD . /go/src/clamav-rest/
+ENV GO111MODULE=auto
 RUN go get github.com/dutchcoders/go-clamd
 RUN go get github.com/prometheus/client_golang/prometheus/promhttp
 ADD ./server.* /etc/ssl/clamav-rest/


### PR DESCRIPTION
Go build changed in 1.16. Modules are no on by default.
This did break the build. Adding the environment variable
GO111MODULE=auto will fix this.

For details see:
https://go.dev/blog/go116-module-changes