### PR TITLE
add /scanBody as a REST handler that simply scans the body w/o using multipart/form-data

### DIFF
--- a/clamrest.go
+++ b/clamrest.go
@@ -136,6 +136,38 @@ func scanHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func scanHandlerBody(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	c := clamd.NewClamd(opts["CLAMD_PORT"])
+
+	fmt.Printf(time.Now().Format(time.RFC3339) + " Started scanning plain body\n")
+	var abort chan bool
+	defer r.Body.Close()
+	response, _ := c.ScanStream(r.Body, abort)
+	for s := range response {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		respJson := fmt.Sprintf("{ Status: %q, Description: %q }", s.Status, s.Description)
+		switch s.Status {
+		case clamd.RES_OK:
+			w.WriteHeader(http.StatusOK)
+		case clamd.RES_FOUND:
+			w.WriteHeader(http.StatusNotAcceptable)
+		case clamd.RES_ERROR:
+			w.WriteHeader(http.StatusBadRequest)
+		case clamd.RES_PARSE_ERROR:
+			w.WriteHeader(http.StatusPreconditionFailed)
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+		fmt.Fprint(w, respJson)
+		fmt.Printf(time.Now().Format(time.RFC3339)+" Scan result for plain body: %v\n", s)
+	}
+}
+
 func waitForClamD(port string, times int) {
 	clamdTest := clamd.NewClamd(port)
 	clamdTest.Ping()
@@ -183,6 +215,7 @@ func main() {
 
 	http.HandleFunc("/scan", scanHandler)
 	http.HandleFunc("/scanPath", scanPathHandler)
+	http.HandleFunc("/scanBody", scanHandlerBody)
 	http.HandleFunc("/", home)
 
 	// Prometheus metrics


### PR DESCRIPTION
For a REST API client the need to POST the file as `multipart/form-data` feels a bit cumbersome. There is only one file to be scanned at a time, its name does not matter either.

This P/R adds another endpoint `/scanBody` that simply scans the posted body. This makes it easier to use:

```sh
$ curl -i -d @eicar.com.txt http://localhost:9000/scanBody
HTTP/1.1 406 Not Acceptable
Content-Type: application/json; charset=utf-8
Date: Thu, 06 Jan 2022 17:04:55 GMT
Content-Length: 56

{ Status: "FOUND", Description: "Win.Test.EICAR_HDB-1" }
```