### PR TITLE
adapted JSON response to be JAVA compatible (RFC 8259)

### DIFF
--- a/clamrest.go
+++ b/clamrest.go
@@ -113,7 +113,7 @@ func scanHandler(w http.ResponseWriter, r *http.Request) {
 			response, err := c.ScanStream(part, abort)
 			for s := range response {
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				respJson := fmt.Sprintf("{ Status: \"%s\", Description: \"%s\" }", s.Status, s.Description)
+				respJson := fmt.Sprintf("{ \"Status\": \"%s\", \"Description\": \"%s\" }", s.Status, s.Description)
 				switch s.Status {
 				case clamd.RES_OK:
 					w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
When using the API from within JAVA, the JSON response results in errors.

Therefore I adapted the Status: and Description: to be in quotes.